### PR TITLE
Added Air Pasteboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ _Please read [contribution guidelines](CONTRIBUTING.md#readme) before contributi
 ## Productivity
 
 - [2Do](https://www.2doapp.com/) - Powerful & flexible GTD task manager.
+- [Air Pasteboard](https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12) - Quick pasteboard and file sharing.
 - [BetterTouchTool](https://www.boastr.net/)
 - [Fantastical](https://flexibits.com/fantastical)
 - [Keyboard Maestro](https://www.keyboardmaestro.com/main/) - Automation engine.


### PR DESCRIPTION
Add Air Pasteboard, which is a Mac OS system bar app that allows you to share pasteboard to gist and files via iCloud and Dropbox.