### PR TITLE
Add BookShelves to Read section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 ## Read
 
+- [BookShelves](https://getbookshelves.app/) - Ebook reader and library manager with 100,000+ free public domain books and iCloud sync.
 - [iBooks](https://www.apple.com/lae/ibooks/)
 - [PDF Expert](https://pdfexpert.com/)
 - [Reeder 3](http://reederapp.com/mac/)


### PR DESCRIPTION
Added [BookShelves](https://getbookshelves.app/) to the Read section.

BookShelves is a native macOS ebook reader and library manager with:
- 100,000+ free public domain books (Standard Ebooks, Internet Archive)
- iCloud sync across Mac, iPhone, and iPad
- EPUB, PDF, MOBI, AZW3 support
- Free on the Mac App Store

[Mac App Store link](https://apps.apple.com/app/bookshelves-ebook-reader/id6756848973)

Entry added in alphabetical order.