### PR TITLE
Add ClearDisk - macOS menu bar cache cleanup utility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Capty](https://capty.app/) - Lightning-fast screen recordings with a native macOS experience.
 - [CleanShot X](https://cleanshot.com/) - Ultimate screen recording app.
 - [Clean my mac 3](https://macpaw.com/cleanmymac)
+- [ClearDisk](https://github.com/bysiber/cleardisk) - macOS menu bar utility that monitors 44+ developer cache paths (Xcode, Docker, npm, pip, Cargo, Homebrew, etc.) and helps reclaim disk space.
 - [Daisy disk](https://daisydiskapp.com/)
 - [Dropzone 4](https://aptonic.com/)
 - [Feather](https://github.com/lukakerr/feather) - Minimal, lightweight MacOS desktop application to check for regular expression pattern matches.


### PR DESCRIPTION
## ClearDisk

A native macOS menu bar utility that monitors **44+ developer cache paths** and helps reclaim disk space with a single click.

### Key Features
- Lives in the menu bar — zero UI clutter
- Monitors Xcode DerivedData, CocoaPods, SPM, Docker, node_modules, pip, Cargo, Homebrew, Gradle, Go modules, and more
- One-click cleanup with safety confirmations
- Built with Swift / SwiftUI

**GitHub:** https://github.com/bysiber/cleardisk
**Website:** https://cleardisk.app

Added under **Utilities** section, alphabetically after Clean my mac 3.