### PR TITLE
Add OpenPaw to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands.
 - [Dash](https://kapeli.com/dash)
 - [Dumper](https://bananafishsoftware.com/products/dumper/) - Extract, browse and inspect the class declarations from any Mach-O file containing Objective-C runtime information.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Personal assistant skills for Claude Code. Focus mode, task dashboard, smart home control, 39 skills. `npx pawmode`
 - [Paw](https://paw.cloud/)
 - [Platypus](https://github.com/sveinbjornt/Platypus) - Create Mac applications from command line scripts.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)


### PR DESCRIPTION
OpenPaw is an open-source personal assistant for Claude Code with 39 skills including focus mode, task dashboard, and smart home control. Available via `npx pawmode`.