### PR TITLE
Add HeyRobyn to Communication apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Airmail](http://airmailapp.com/)
 - [Gitter](https://gitter.im/apps)
+- [HeyRobyn](https://heyrobyn.ai) - Native macOS unified inbox combining email, Slack, and GitHub in one window.
 - [Slack](https://slack.com/)
 - [Telegram](https://telegram.org/)
 - [Textual](https://www.codeux.com/textual/)


### PR DESCRIPTION
Hi! I'd like to suggest adding HeyRobyn to the Communication apps section.

HeyRobyn is a native macOS unified inbox that combines email, Slack, and GitHub notifications in one window, helping users manage multiple communication channels without context switching.

Website: https://heyrobyn.ai

This app has been genuinely helpful for staying focused and achieving inbox zero across multiple platforms.

Thank you for maintaining this great list!