### PR TITLE
Add Lockpaw — menu bar screen guard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Karabiner](https://pqrs.org/osx/karabiner/) - Powerful keyboard customizer.
 - [Keka](https://www.keka.io)
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html)
+- [Lockpaw](https://github.com/sorkila/lockpaw) - Menu bar screen guard that lets you cover your screen with a hotkey while background tasks keep running.
 - [Lumen](https://github.com/anishathalye/lumen)
 - [MonthlyCal](https://itunes.apple.com/us/app/monthlycal-colorful-monthly/id935250717?mt=12) - Notification Center Calendar
 - [Name mangler](https://manytricks.com/namemangler/)


### PR DESCRIPTION
## Summary

- Add [Lockpaw](https://github.com/sorkila/lockpaw) to the Utilities section
- Open-source (MIT) macOS menu bar app — cover your screen with a hotkey while AI agents and background tasks keep running
- 79+ GitHub stars

Follows the existing entry format, placed in alphabetical order.