### PR TITLE
Add Kaset to Music

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 ## Music
 
+- [Kaset](https://github.com/sozercan/kaset) - Native YouTube Music client for macOS.
 - [Noizio](http://noiz.io/)
 - [Spotify](https://www.spotify.com/)
 - [Tine Player](http://www.catnapgames.com/tiny-player-for-mac/)


### PR DESCRIPTION
## Summary
- add Kaset to the `Music` section

## Why
Kaset is a native macOS YouTube Music client built with Swift and SwiftUI, so it fits this curated macOS apps list.

## Validation
- confirmed there was no existing Kaset entry
- ran `git diff --check`