### PR TITLE
Add Murmur to Audio section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Ardour](https://ardour.org) - Record, edit, and mix audio in a production-level environment.
 - [Audio Hijack](https://rogueamoeba.com/audiohijack/) - Record any application's audio, including VoIP calls from Skype, web streams from Safari, and much more.
+- [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and offline generation on Apple Silicon.
 
 ## Code
 


### PR DESCRIPTION
Adding [Murmur](https://murmurtts.com/) to the Audio section.

Murmur is an on-device text-to-speech studio for macOS. It runs 860+ voices across 25+ languages, supports voice cloning from a 10-second sample, and generates audio entirely on the user's Mac via Apple's MLX framework. No cloud calls, no telemetry.

Used by podcasters, audiobook authors, YouTubers, and newsletter writers who want local-first audio generation without per-character pricing.

### Checklist

- [x] Searched for duplicates before adding
- [x] Format: `- [Name](link) - Description.`
- [x] Description starts with a capital and ends with a period
- [x] Description does not start with "A" or "An"
- [x] Placed in alphabetical order in the Audio section