### PR TITLE
Add AI Dictation to Write

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 ## Write
 
+- [AI Dictation](https://aidictation.com/) - Speech-to-text dictation that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app.
 - [adoc Studio](https://www.adoc-studio.app) - Technical Writing in AsciiDoc.
 - [Day One](http://dayoneapp.com/)
 - [FSNotes](https://github.com/glushchenko/fsnotes) - Notes manager.

--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 ## Write
 
+- [AI Dictation](https://aidictation.com/) - Voice-to-text app with MIT-licensed native client source, offline recognition on supported Macs, and optional cloud transcription and cleanup.
 - [adoc Studio](https://www.adoc-studio.app) - Technical Writing in AsciiDoc.
 - [Day One](http://dayoneapp.com/)
 - [FSNotes](https://github.com/glushchenko/fsnotes) - Notes manager.


### PR DESCRIPTION
## Summary

- Add AI Dictation to the Write section.
- Describe its MIT-licensed native client source, offline recognition on supported Macs, and optional cloud transcription and cleanup.

## Validation

- Confirmed the entry follows contributing.md formatting and placement rules.
- Confirmed AI Dictation appears exactly once in readme.md.
- Ran git diff --check.
- Verified https://aidictation.com returns HTTP 200.
- Verified the current public source, MIT license, and macOS release in writingmate/aidictation.

## Disclosure

I am on the team behind AI Dictation. This update was prepared with AI assistance and then reviewed and validated before submission.