### PR TITLE
Add OpenQuack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Ardour](https://ardour.org) - Record, edit, and mix audio in a production-level environment.
 - [Audio Hijack](https://rogueamoeba.com/audiohijack/) - Record any application's audio, including VoIP calls from Skype, web streams from Safari, and much more.
+- [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app powered by WhisperKit.
 
 ## Code
 


### PR DESCRIPTION
Adds OpenQuack — privacy-first local voice dictation menu bar app for macOS, MIT-licensed, ~8 MB Swift binary running WhisperKit on Apple Silicon — to the Audio section.

- Repo: https://github.com/larryxiao/openquack
- License: MIT
- Format: matched to existing entries — `- [Name](URL) - Description.` per `contributing.md`.
- Position: alphabetical (after Audio Hijack).

Thanks for maintaining the list!