### PR TITLE
Add Clipport to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Dev tools
 
 - [Bee](https://www.neat.io/bee/) - Issue tracker.
+- [Clipport](https://github.com/arihantsethia/clipport) - Paste local clipboard text and images into remote iTerm sessions.
 - [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands.
 - [Dash](https://kapeli.com/dash)
 - [Dumper](https://bananafishsoftware.com/products/dumper/) - Extract, browse and inspect the class declarations from any Mach-O file containing Objective-C runtime information.


### PR DESCRIPTION
Adds Clipport to Dev tools.\n\nProject: https://github.com/arihantsethia/clipport\n\nWhy it belongs: Clipport is a macOS developer tool for iTerm and SSH workflows. It lets remote-dev users paste local clipboard text and screenshots into remote sessions without manually saving and scp-ing files.\n\nThe entry follows the list's short description format and ends with a full stop.