### PR TITLE
Add Markup (Write)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,6 +205,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [FSNotes](https://github.com/glushchenko/fsnotes) - Notes manager.
 - [MacDown](https://macdown.uranusjr.com/)
 - [Marked 2](http://marked2app.com/)
+- [Markup](https://github.com/oratis/Markup) - Reader-first native Markdown editor; reads .md like a web page, edit on demand.
 - [Texpad](https://www.texpad.com/)
 - [Ulysses](https://ulyssesapp.com/) - Writing app.
 


### PR DESCRIPTION
Adds **Markup** to the **Write** section.

- **Repo:** https://github.com/oratis/Markup
- Free, open-source (MIT), native macOS Markdown editor. Reader-first: renders `.md` like a clean web page and edits on demand; vault with wikilinks/backlinks/graph and full-text search.

Placed alphabetically between Marked 2 and Texpad; description capitalized and ends with a period.