### PR TITLE
Add Stargazer Bar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Paw](https://paw.cloud/)
 - [Platypus](https://github.com/sveinbjornt/Platypus) - Create Mac applications from command line scripts.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
+- [Stargazer Bar](https://github.com/jazzyalex/stargazer-bar) - Track one public GitHub repo's stars and release downloads from the menu bar.
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
 - [Tower](https://www.git-tower.com/mac/)
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) - Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.


### PR DESCRIPTION
Adds Stargazer Bar to the Dev tools section.

It is an open-source native macOS menu bar app for tracking one public GitHub repo's stars and release downloads.

Checklist:
- Searched existing macOS apps for duplicates.
- Added one entry in the closest existing category.
- Description starts with a capital and ends with a full stop.