### PR TITLE
Add DailyDesk to productivity apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [2Do](https://www.2doapp.com/) - Powerful & flexible GTD task manager.
 - [Air Pasteboard](https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12) - Quick pasteboard and file sharing.
 - [BetterTouchTool](https://www.boastr.net/)
+- [DailyDesk](https://github.com/StaryMoon/DailyDesk) - Native Swift/AppKit glass desktop planner with recurring tasks, local rewards, and a tiny desktop pet.
 - [Fantastical](https://flexibits.com/fantastical)
 - [Keyboard Maestro](https://www.keyboardmaestro.com/main/) - Automation engine.
 - [Merlin Project](https://www.projectwizards.net/en/merlin-project) – Project Management on macOS & iOS.


### PR DESCRIPTION
## Summary\n\nAdds DailyDesk to the Productivity section.\n\n## Added app\n\n- https://github.com/StaryMoon/DailyDesk\n\n## Why it fits\n\nDailyDesk is a native Swift/AppKit macOS desktop planner with recurring tasks, local rewards, and a tiny desktop pet. It fits the productivity category as a lightweight task-planning desktop utility.\n\nThanks for maintaining this list.