### PR TITLE
Add Mac Mouse Fixer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Karabiner](https://pqrs.org/osx/karabiner/) - Powerful keyboard customizer.
 - [Keka](https://www.keka.io)
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html)
+- [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [Lumen](https://github.com/anishathalye/lumen)
 - [MonthlyCal](https://itunes.apple.com/us/app/monthlycal-colorful-monthly/id935250717?mt=12) - Notification Center Calendar
 - [Name mangler](https://manytricks.com/namemangler/)


### PR DESCRIPTION
Adds Mac Mouse Fixer to Utilities.

Mac Mouse Fixer helps external mouse users on macOS fix accidental double-clicks and add smooth scrolling, horizontal scrolling, and wheel zoom.