### PR TITLE
Add Pesty (clipboard manager) to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [MindNode](https://mindnode.com/) - Create interactive mind maps.
 - [Next meeting](https://itunes.apple.com/us/app/next-meeting-quickly-see-it-in-your-menu-bar/id1017470484?mt=12)
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - Tag and archive documents.
+- [Pesty](https://github.com/momenbasel/pesty) - Color-coded clipboard manager with pinboards, instant search, and keyboard-driven pasting.
 - [Timing 2](https://betalist.com/startups/timing-2)
 - [TogglDesktop](https://support.toggl.com/toggl-on-my-desktop/)
 - [Trello](https://itunes.apple.com/app/trello/id1278508951?ls=1&mt=12)


### PR DESCRIPTION
Adds Pesty to the Productivity section.

Pesty is a free, open-source, native SwiftUI clipboard manager for macOS - a slide-up, color-coded clipboard strip with pinboards, instant search, and keyboard-driven pasting. It sits naturally next to the existing "Air Pasteboard" entry and broadens the list's thin clipboard/pasteboard coverage.

Why it belongs on this list:
- Native macOS app (SwiftUI), universal binary, Developer ID signed and Apple-notarized.
- Free and open-source (MIT), with zero third-party dependencies.
- Easy install via Homebrew: `brew install --cask momenbasel/pesty/pesty`.
- Also available on the Mac App Store for those who prefer it.

Entry added (follows the list format - capitalized description, ends with a full stop, no leading "A"/"An"):

`- [Pesty](https://github.com/momenbasel/pesty) - Color-coded clipboard manager with pinboards, instant search, and keyboard-driven pasting.`

Placed in Productivity after "PDF Archiver" to respect the section's alphabetical ordering.

Repo: https://github.com/momenbasel/pesty
Landing page: https://www.moamenbasel.com/pesty/