### PR TITLE
Add Off Grid AI Desktop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Merlin Project](https://www.projectwizards.net/en/merlin-project) – Project Management on macOS & iOS.
 - [MindNode](https://mindnode.com/) - Create interactive mind maps.
 - [Next meeting](https://itunes.apple.com/us/app/next-meeting-quickly-see-it-in-your-menu-bar/id1017470484?mt=12)
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) - Open-source local AI suite that runs LLM chat, image generation, whisper transcription, memory search, and an encrypted vault on-device with no account or cloud.
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - Tag and archive documents.
 - [Timing 2](https://betalist.com/startups/timing-2)
 - [TogglDesktop](https://support.toggl.com/toggl-on-my-desktop/)


### PR DESCRIPTION
Adds Off Grid AI Desktop to the Productivity section.

Off Grid AI Desktop is a free, open-source (AGPL-3.0) macOS app that runs a full AI suite on-device: local LLM chat (llama.cpp), image generation, whisper transcription/dictation, personal memory/RAG search, clipboard manager, encrypted vault, and MCP connectors. No account, no telemetry, no cloud.

- Repo: https://github.com/off-grid-ai/off-grid-ai-desktop
- Site: https://getoffgridai.co/desktop

Entry follows the list format and is placed alphabetically in Productivity.

Disclosure: I'm involved with the project.