### PR TITLE
Add usage to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
 - [Tower](https://www.git-tower.com/mac/)
+- [usage](https://github.com/aqua5230/usage) - Claude Code and Codex quota in the menu bar, with burn-rate predictions and offline HTML reports.
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) - Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.
 
 ## Games

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
 - [Tower](https://www.git-tower.com/mac/)
-- [usage](https://github.com/aqua5230/usage) - Claude Code and Codex quota in the menu bar, with burn-rate predictions and offline HTML reports.
+- [usage](https://github.com/aqua5230/usage) - Claude Code, Codex, and Antigravity quota in the menu bar, with burn-rate predictions and offline HTML reports.
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) - Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.
 
 ## Games


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — an open-source (AGPL-3.0) macOS menu bar app that pins Claude Code and Codex quota (5-hour / weekly) to the screen, with burn-rate predictions and offline HTML usage reports. It never calls the Anthropic/OpenAI API; all numbers come from local files, so monitoring adds zero token overhead. Installable via `brew install --cask aqua5230/usage/usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)