### PR TITLE
Add ClipBridge to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [2Do](https://www.2doapp.com/) - Powerful & flexible GTD task manager.
 - [Air Pasteboard](https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12) - Quick pasteboard and file sharing.
 - [BetterTouchTool](https://www.boastr.net/)
+- [ClipBridge](https://github.com/andreasserfilippi/clipbridge) - Self-hosted clipboard sync between iPhone, Windows, and Mac.
 - [Fantastical](https://flexibits.com/fantastical)
 - [Keyboard Maestro](https://www.keyboardmaestro.com/main/) - Automation engine.
 - [Merlin Project](https://www.projectwizards.net/en/merlin-project) – Project Management on macOS & iOS.


### PR DESCRIPTION
Adds ClipBridge, a self-hosted clipboard sync tool between iPhone, Windows, and Mac, alongside Air Pasteboard in Productivity.

- Open source, MIT licensed
- Each user deploys their own backend, nothing shared or centralized