### PR TITLE
Add echo99 to Audio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Ardour](https://ardour.org) - Record, edit, and mix audio in a production-level environment.
 - [Audio Hijack](https://rogueamoeba.com/audiohijack/) - Record any application's audio, including VoIP calls from Skype, web streams from Safari, and much more.
+- [echo99](https://www.echo99.app/) - Privacy-focused call recorder with on-device transcription and speaker labels.
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app powered by WhisperKit.
 
 ## Code


### PR DESCRIPTION
## What changed

- Added echo99 to the Audio section.

## Why

echo99 is a privacy-focused Mac call recorder with on-device transcription and speaker labels.

## Validation

- Confirmed there is no existing echo99 issue or pull request.
- Confirmed the official product page supports the description.
- Confirmed only `readme.md` changed.
- Ran `git diff --check`.
