### PR TITLE
Add Waindow to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Typinator](http://www.ergonis.com/products/typinator/) - Text expansions.
 - [Unclutter](https://unclutterapp.com/)
 - [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover.
+- [Waindow](https://www.waindow.app/) - Free native macOS utility for arranging windows, keeping window-linked Markdown memos, capturing long pages, and preventing idle sleep.
 - [ZoomShot](https://apps.apple.com/app/zoomshot-live-screen-effect/id6758536367) - Real-time screen zoom, cursor highlight, drawing, and text memo for presentations and recordings.
 
 ## Video


### PR DESCRIPTION
## What changed

- Added Waindow to the Utilities section using the list's required format.

## Why

Waindow is a free native macOS utility for window arrangement, window-linked Markdown memos, long-page capture, and sleep prevention. It is available without an account from its public product page.

## Checks

- Searched the list and found no existing Waindow entry.
- Confirmed the product URL responds successfully.
- Kept the change to one README entry with a capitalized description and full stop.
