### PR TITLE
Add Glyph to Write apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [adoc Studio](https://www.adoc-studio.app) - Technical Writing in AsciiDoc.
 - [Day One](http://dayoneapp.com/)
 - [FSNotes](https://github.com/glushchenko/fsnotes) - Notes manager.
+- [Glyph](https://glyphformac.com/) - Offline-first notes for macOS, built around local Markdown files. [Source](https://github.com/SidhuK/Glyph)
 - [MacDown](https://macdown.uranusjr.com/)
 - [Marked 2](http://marked2app.com/)
 - [Texpad](https://www.texpad.com/)


### PR DESCRIPTION
## What changed

- Added Glyph to the Write section in alphabetical order.
- Linked the official website and included the source repository as a related link.

## About Glyph

Glyph is an offline-first notes app for macOS built around local Markdown files.
Its source code is available under AGPL-3.0, while the official macOS builds are
commercial one-time-purchase releases with a 7-day trial.

## Validation

- Confirmed the entry follows `contributing.md` and the existing Write-section format.
- Ran `git diff --check`.
