### PR TITLE
Add Tintpad to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Platypus](https://github.com/sveinbjornt/Platypus) - Create Mac applications from command line scripts.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
+- [Tintpad](https://github.com/sorkila/tintpad) - Menu bar launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running.
 - [Tower](https://www.git-tower.com/mac/)
 - [VirtualBox](https://www.virtualbox.org/wiki/Downloads) - Powerful x86 and AMD64/Intel64 virtualization product for enterprise as well as home use.
 


### PR DESCRIPTION
Adds [Tintpad](https://github.com/sorkila/tintpad), a free, open-source (MIT) menu bar launcher for coding agents: global hotkey, fuzzy-find a repo, pick an agent (Claude Code, Codex, ...) and run mode, and your own terminal opens at that repo with the agent running. Native Swift/SwiftUI, local-only, no accounts.

Follows the guidelines: alphabetical placement in Dev tools, description starts with a capital, ends with a full stop, no leading article. Checked for duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)