### PR TITLE
Add ItsPaint to Design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Framer X](https://framer.com/) - Interactive design tool.
 - [Iconizer](http://raphaelhanneken.github.io/iconizer/) - Create Xcode asset catalogs on the fly.
 - [Image2icon](http://www.img2icnsapp.com/) - Create and personalize icons from your pictures.
+- [ItsPaint](https://github.com/joshlin2201/itspaint) - Paint app for blank canvases, quick edits and screenshot markup. Free and open source.
 - [Patina](http://www.patinaapp.com/)
 - [Pixelmator](http://www.pixelmator.com/mac/)
 - [Sip](http://sipapp.io/)

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Framer X](https://framer.com/) - Interactive design tool.
 - [Iconizer](http://raphaelhanneken.github.io/iconizer/) - Create Xcode asset catalogs on the fly.
 - [Image2icon](http://www.img2icnsapp.com/) - Create and personalize icons from your pictures.
-- [ItsPaint](https://github.com/joshlin2201/itspaint) - Paint app for blank canvases, quick edits and screenshot markup. Free and open source.
+- [ItsPaint](https://itspaintmac.com/) - Paint app for blank canvases, quick edits and screenshot markup. Free and open source.
 - [Patina](http://www.patinaapp.com/)
 - [Pixelmator](http://www.pixelmator.com/mac/)
 - [Sip](http://sipapp.io/)


### PR DESCRIPTION
ItsPaint is a small native paint app for macOS — blank canvas at any size, paste or drag an image onto another one, crop, and screenshot markup with numbered step badges and pixelate.

Native AppKit/SwiftUI, MIT licensed, no third-party dependencies, notarised, universal (Apple silicon and Intel), and under 3 MB. No account and no telemetry.

Disclosure: I am the developer.

https://github.com/joshlin2201/itspaint