### PR TITLE
Add CopySight to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Chronosync](https://www.econtechnologies.com/chronosync/overview.html)
 - [Capty](https://capty.app/) - Lightning-fast screen recordings with a native macOS experience.
 - [CleanShot X](https://cleanshot.com/) - Ultimate screen recording app.
+- [CopySight](https://apps.apple.com/app/id6797554906) - Copy text from any screen region with private, on-device OCR.
 - [Clean my mac 3](https://macpaw.com/cleanmymac)
 - [ClearDisk](https://github.com/bysiber/cleardisk) - macOS menu bar utility that monitors 44+ developer cache paths (Xcode, Docker, npm, pip, Cargo, Homebrew, etc.) and helps reclaim disk space.
 - [Daisy disk](https://daisydiskapp.com/)


### PR DESCRIPTION
I maintain CopySight. This adds it to Utilities with a concise description.

CopySight copies text from any screen region using private, on-device OCR. The listing links directly to the Mac App Store, where pricing is configured as a $0.99 one-time purchase.

Validation:
- App Store link resolves successfully
- Entry follows the documented format and ends with a period
- `git diff --check`