### PR TITLE
Add TabControl

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Timing 2](https://betalist.com/startups/timing-2)
 - [TogglDesktop](https://support.toggl.com/toggl-on-my-desktop/)
 - [Trello](https://itunes.apple.com/app/trello/id1278508951?ls=1&mt=12)
+- [TabControl](https://tabcontrol.app/) - Safari tab manager for saving sessions, restoring tabs, and suspending inactive pages.
 - [Taskade](https://taskade.com/) - Simple and sharable task lists, notes and outlines.
 - [Up Next](http://ellen.li/up-next/) - See your day at a glance. Integrated with Google Meet so you can join meetings with ⌘J.
 


### PR DESCRIPTION
## Summary

- Add TabControl to the Productivity section.
- Make it discoverable alongside other macOS productivity tools.

## Validation

- `git diff --check`
