### PR TITLE
Add Belay to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [AgentGrid](https://agentgrid.sh) - Infinite zoomable canvas for orchestrating multiple AI coding agents in parallel, with role-based workers, per-agent git worktrees, and integrated terminals and browser panes.
 - [Bee](https://www.neat.io/bee/) - Issue tracker.
+- [Belay](https://perfectoweb.github.io/Belay/en/) - Keeps a Mac awake while local coding agents work, then lets it sleep when they're done.
 - [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands.
 - [Dash](https://kapeli.com/dash)
 - [Dumper](https://bananafishsoftware.com/products/dumper/) - Extract, browse and inspect the class declarations from any Mach-O file containing Objective-C runtime information.


### PR DESCRIPTION
Adds Belay to the Dev tools section (alphabetical).

Belay (https://perfectoweb.github.io/Belay/en/) is a native macOS menu bar
utility that keeps a Mac awake while local coding agents are working and
lets it sleep again when they're done. Free, source available:
https://github.com/PerfectoWeb/Belay

Format follows the neighbouring entries in the Dev tools section.
