### PR TITLE
Add Notula to Write

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [FSNotes](https://github.com/glushchenko/fsnotes) - Notes manager.
 - [MacDown](https://macdown.uranusjr.com/)
 - [Marked 2](http://marked2app.com/)
+- [Notula](https://notula.org) - WYSIWYG editor for the Markdown documentation in a git repository, with comment threads committed beside the documents.
 - [Texpad](https://www.texpad.com/)
 - [Ulysses](https://ulyssesapp.com/) - Writing app.
 


### PR DESCRIPTION
Adds **Notula** to Write, alphabetically between Marked 2 and Texpad.

Notula is a free desktop editor for the Markdown documentation that already lives in a git repository. It shows the repository as a tree of documents rather than a file list, edits them WYSIWYG with no syntax on screen, and adds a review layer: comment on a passage, reply, mention, resolve. The threads are committed next to the documents as plain files, so they arrive with a clone and nothing is written into the Markdown itself. Free, no account and no server; Apple Silicon and Intel.

Checked against `contributing.md`: not a duplicate, `- [Name](link) - Description.` format, description starts with a capital and ends with a full stop, does not start with "A" or "An", and it sits in the section next to the other writing tools rather than in Text Editors.
