### PR TITLE
Add Downright

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Atom](https://atom.io)
 - [Code runner](https://coderunnerapp.com/)
+- [Downright](https://downright.cc/) - Native Markdown reader and editor with Quick Look previews and source-preserving formatted editing.
 - [Sublime Text](https://www.sublimetext.com/)
 - [VS Code](https://code.visualstudio.com/)
 


### PR DESCRIPTION
I’m the author of Downright. It is a free, MIT-licensed native Mac app for reading and editing Markdown files. The entry is in Text Editors and follows the list’s format.