### PR TITLE
Add Sundown to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Pacifist](http://www.charlessoft.com/) - Opens Mac OS X .pkg package files, .dmg disk images, and .zip, .tar, .tar.gz, .tar.bz2, and .xar archives and allows you to extract individual files and folders out of them.
 - [Popclip](https://pilotmoon.com/popclip/)
 - [Spotifree](http://spotifree.gordinskiy.com/)
+- [Sundown](https://trysundown.com/) - Warms and dims the display beyond Night Shift's limits on a sunset-to-sunrise schedule.
 - [Swish](https://highlyopinionated.co/swish/) - A gesture layer and window manager for the trackpad power user.
 - [Typinator](http://www.ergonis.com/products/typinator/) - Text expansions.
 - [Unclutter](https://unclutterapp.com/)


### PR DESCRIPTION
Adds **Sundown** to Utilities (alphabetical, between Spotifree and Swish).

[Sundown](https://trysundown.com/) is a Mac menu-bar app that warms and dims the display beyond Night Shift's limits — down to 500K color temperature — on a sunset-to-sunrise schedule. Gamma-curve dimming takes the screen darker than the backlight floor without added flicker; six one-click presets. Native Swift, no Electron (~6 MB download), macOS 14+.

Paid app ($4.99/mo · $39/yr · $79 lifetime) with a 7-day free trial.

Disclosure: I'm the developer. Happy to adjust wording or placement.
