### PR TITLE
Add LeafyApp to Learn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Learn
 
 - [Anki](https://apps.ankiweb.net/)
-- [Leafy](https://leafyapp.uk) - Menu bar vocabulary builder that saves any word on screen with the sentence around it.
+- [LeafyApp](https://leafyapp.uk) - Menu bar vocabulary builder that saves any word on screen with the sentence around it.
 - [Soulver](http://acqualia.com/soulver/)
 
 ## Music

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Learn
 
 - [Anki](https://apps.ankiweb.net/)
+- [Leafy](https://leafyapp.uk) - Menu bar vocabulary builder that saves any word on screen with the sentence around it.
 - [Soulver](http://acqualia.com/soulver/)
 
 ## Music


### PR DESCRIPTION
Adds Leafy to Learn.

A shortcut boxes any word on screen and saves it together with the sentence it appeared in, so the word list keeps the context you met the word in. Saved words can be reviewed later with the word blanked out of that sentence. It reads the screen rather than a text selection, so PDFs, scans and subtitles work too.

Free, macOS 14+, native Swift.

Disclosure: I'm the developer.
