### PR TITLE
Add nowbar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Spotify](https://www.spotify.com/)
 - [Tine Player](http://www.catnapgames.com/tiny-player-for-mac/)
 - [LyricsX](https://github.com/ddddxxx/LyricsX) - Ultimate lyrics app for macOS.
+- [nowbar](https://github.com/arian-shamaei/nowbar) - Menu bar Now Playing item replaced with the live album art of the current track.
 
 ## Productivity
 


### PR DESCRIPTION
Adds nowbar to Music: a menu bar item that replaces the static Now Playing glyph with the live album art of the current track. Swift, open source, on the Mac App Store. Follows the entry format.