### PR TITLE
Add Tracexy to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Popclip](https://pilotmoon.com/popclip/)
 - [Spotifree](http://spotifree.gordinskiy.com/)
 - [Swish](https://highlyopinionated.co/swish/) - A gesture layer and window manager for the trackpad power user.
+- [Tracexy](https://rockxy.io/tracexy) - Native, local-first network intelligence for investigating live traffic and PCAP or PCAPNG captures as app-aware sessions.
 - [Typinator](http://www.ergonis.com/products/typinator/) - Text expansions.
 - [Unclutter](https://unclutterapp.com/)
 - [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover.


### PR DESCRIPTION
## Summary

- Add Tracexy to the Utilities section.

## Why

Tracexy is a native, local-first macOS network intelligence app for investigating live traffic and saved PCAP or PCAPNG captures as app-aware sessions. It fits Utilities alongside network and system tools such as Little Snitch.

## Contribution guidelines

- Confirmed Tracexy is not already listed or proposed.
- Used the required `- [Name](link) - Description.` format.
- Started the description with a capital, avoided “A” and “An,” and ended it with a full stop.
- Selected the closest existing category.

## Validation

- Verified the official website and public source repository return HTTP 200.
- Ran `git diff --check`.

Disclosure: I am a Tracexy maintainer.