### PR TITLE
Add Rockxy to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [OpenPaw](https://github.com/daxaur/openpaw) - Personal assistant skills for Claude Code. Focus mode, task dashboard, smart home control, 39 skills. `npx pawmode`
 - [Paw](https://paw.cloud/)
 - [Platypus](https://github.com/sveinbjornt/Platypus) - Create Mac applications from command line scripts.
+- [Rockxy](https://rockxy.io) - Native HTTP debugging proxy for intercepting HTTPS, inspecting APIs, mocking responses, and debugging WebSocket and GraphQL traffic.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
 - [Tower](https://www.git-tower.com/mac/)


### PR DESCRIPTION
## Summary

- Add Rockxy to the Dev tools section.

## Why

Rockxy is a native macOS HTTP debugging proxy for intercepting HTTPS, inspecting APIs, mocking responses, and debugging WebSocket and GraphQL traffic. It fits Dev tools alongside other software-development and inspection utilities.

## Contribution guidelines

- Confirmed Rockxy is not already listed or proposed.
- Used the required `- [Name](link) - Description.` format.
- Started the description with a capital, avoided “A” and “An,” and ended it with a full stop.
- Selected the closest existing category.

## Validation

- Verified the official website and public AGPL-3.0 repository return HTTP 200.
- Confirmed v0.36.0 is the current public release.
- Ran `git diff --check`.

Disclosure: I am a Rockxy maintainer.