### PR TITLE
Add amtrino

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Dev tools
 
 - [AgentGrid](https://agentgrid.sh) - Infinite zoomable canvas for orchestrating multiple AI coding agents in parallel, with role-based workers, per-agent git worktrees, and integrated terminals and browser panes.
+- [amtrino](https://github.com/arian-shamaei/amtrino) - Every AI coding session on your Mac at a glance, one breathing menu bar dot each.
 - [Bee](https://www.neat.io/bee/) - Issue tracker.
 - [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands.
 - [Dash](https://kapeli.com/dash)


### PR DESCRIPTION
Adds amtrino to Dev tools: a menu bar app that shows every AI coding session (Claude Code, Codex CLI) on the Mac as one breathing dot each. Swift, open source, Homebrew cask. Follows the entry format, alphabetical.