### PR TITLE
Add FunNotch to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Daisy disk](https://daisydiskapp.com/)
 - [Dropzone 4](https://aptonic.com/)
 - [Feather](https://github.com/lukakerr/feather) - Minimal, lightweight MacOS desktop application to check for regular expression pattern matches.
+- [FunNotch](https://funnotch.xyz) - Puts the space around the MacBook camera to work with media controls, a drag-and-drop file shelf, clipboard history, focus sessions and twelve widgets. Free and open source.
 - [Gitify](https://github.com/manosim/gitify)
 - [Hammerspoon](http://www.hammerspoon.org/)
 - [Hummingbird](https://hummingbirdapp.site) - Easily move and resize windows without mouse clicks, from anywhere within a window.


### PR DESCRIPTION
Adds **FunNotch** to *Utilities*, placed alphabetically between Feather and Gitify.

```
- [FunNotch](https://funnotch.xyz) - Puts the space around the MacBook camera to work with media controls, a drag-and-drop file shelf, clipboard history, focus sessions and twelve widgets. Free and open source.
```

- **Site:** https://funnotch.xyz
- **Source:** https://github.com/JoshuaT1105/FunNotch (GPL-3.0, Swift/SwiftUI)
- **Requirements:** macOS 14+, universal (Apple Silicon and Intel), no account, no telemetry

Follows contributing.md: searched for an existing entry first (none), single category, description starts capitalised, ends with a full stop, and does not begin with "A"/"An".