### PR TITLE
Add Plainsay to Audio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Ardour](https://ardour.org) - Record, edit, and mix audio in a production-level environment.
 - [Audio Hijack](https://rogueamoeba.com/audiohijack/) - Record any application's audio, including VoIP calls from Skype, web streams from Safari, and much more.
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app powered by WhisperKit.
+- [Plainsay](https://plainsay.app/) - Native local-first dictation with Whisper and Parakeet, reproducible benchmarks, and an MIT-licensed client.
 
 ## Code
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Ardour](https://ardour.org) - Record, edit, and mix audio in a production-level environment.
 - [Audio Hijack](https://rogueamoeba.com/audiohijack/) - Record any application's audio, including VoIP calls from Skype, web streams from Safari, and much more.
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app powered by WhisperKit.
-- [Plainsay](https://plainsay.app/) - Native local-first dictation with Whisper and Parakeet, reproducible benchmarks, and an MIT-licensed client.
+- [Plainsay](https://plainsay.app/) - Hold a key, speak, and the text appears where you were typing; transcription runs on your Mac.
 
 ## Code
 


### PR DESCRIPTION
Adds [Plainsay](https://github.com/conrader/plainsay), a free and MIT-licensed dictation app for macOS.

Hold a key, speak, and the text is inserted into whatever app you were already typing in. Speech recognition runs on the Mac through Core ML — WhisperKit or NVIDIA Parakeet — so dictation works with no account and no network once the model is downloaded. Optional cloud transcription and cleanup exist, but they are separate, explicit choices rather than the default.

Put in **Audio** next to OpenQuack, which is the closest existing entry — same category of tool, so it seemed the right neighbour rather than a new section.

Checked against contributing.md: searched for an existing entry first (none), format is `- [Name](link) - Description.`, description starts with a capital, ends with a full stop, and does not begin with "A" or "An".

- Free, no subscription for the local mode
- macOS 14+, Apple silicon
- `brew install --cask conrader/plainsay/plainsay`